### PR TITLE
Add panel arg to submit

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -16,6 +16,7 @@ import { IMapChange } from '@jupyter/ydoc';
 import type { PartialJSONValue } from '@lumino/coreutils';
 import { Awareness } from 'y-protocols/awareness';
 import { Contents } from '@jupyterlab/services';
+import { JudgePanel } from './widgets';
 
 export class JudgeModel implements DocumentRegistry.IModel {
   constructor(problemProvider: IProblemProvider) {
@@ -240,9 +241,10 @@ export class JudgeModel implements DocumentRegistry.IModel {
   }
 
   async submit(
-    request: ProblemProvider.ISubmissionRequest
+    request: ProblemProvider.ISubmissionRequest,
+    panel: JudgePanel
   ): Promise<ProblemProvider.ISubmission> {
-    const submission = await this._problemProvider.submit(request);
+    const submission = await this._problemProvider.submit(request, panel);
     this._submissionsChanged.emit(
       await this._problemProvider.getSubmissions(this.sharedModel.problemId)
     );

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -25,7 +25,8 @@ export interface IProblemProvider {
   ): Promise<ProblemProvider.IValidateResult>;
   getSubmissions(id: string): Promise<ProblemProvider.ISubmission[]>;
   submit(
-    request: ProblemProvider.ISubmissionRequest
+    request: ProblemProvider.ISubmissionRequest,
+    panel: JudgePanel
   ): Promise<ProblemProvider.ISubmission>;
 }
 

--- a/src/widgets/JudgePanel.ts
+++ b/src/widgets/JudgePanel.ts
@@ -456,19 +456,22 @@ export class JudgePanel extends BoxPanel {
     await kernel.shutdown();
     kernel.dispose();
 
-    const submission = await this.model.submit({
-      problemId: problem.id,
-      status: status,
-      code,
-      cpuTime:
-        results.map(result => result.cpuTime).reduce((a, b) => a + b, 0) /
-        results.length,
-      acceptedCount: validateResult.acceptedCount,
-      totalCount: validateResult.totalCount,
-      token: validateResult.token,
-      language: 'python',
-      memory: 0
-    });
+    const submission = await this.model.submit(
+      {
+        problemId: problem.id,
+        status: status,
+        code,
+        cpuTime:
+          results.map(result => result.cpuTime).reduce((a, b) => a + b, 0) /
+          results.length,
+        acceptedCount: validateResult.acceptedCount,
+        totalCount: validateResult.totalCount,
+        token: validateResult.token,
+        language: 'python',
+        memory: 0
+      },
+      this
+    );
 
     this.model.submissionStatus = { type: 'idle' };
 


### PR DESCRIPTION
Now panel is passed to `submit`, so additional context information can be added to the requested submission.