### PR TITLE
Add `controlButtonFactory` Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 1.26.1rc1
-
-No merged PRs
-
-<!-- <END NEW CHANGELOG ENTRY> -->
-
-## 1.26.1rc0
-
-No merged PRs
-
 ## 1.26.0
 
 ([Full Changelog](https://github.com/team-monolith-product/jupyterlab-judge/compare/v1.25.0...3f2ecaa9ab61746a3e0ed92d8eac60a7fec05819))
@@ -25,6 +15,8 @@ No merged PRs
 ([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-judge/graphs/contributors?from=2024-04-27&to=2024-06-07&type=c))
 
 [@paulkim3151](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-judge+involves%3Apaulkim3151+updated%3A2024-04-27..2024-06-07&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 1.26.1rc0
+## 1.26.1rc1
 
 No merged PRs
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 1.26.1rc0
+
+No merged PRs
 
 ## 1.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.26.1rc0
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.26.0
 
 ([Full Changelog](https://github.com/team-monolith-product/jupyterlab-judge/compare/v1.25.0...3f2ecaa9ab61746a3e0ed92d8eac60a7fec05819))
@@ -15,8 +21,6 @@
 ([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-judge/graphs/contributors?from=2024-04-27&to=2024-06-07&type=c))
 
 [@paulkim3151](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-judge+involves%3Apaulkim3151+updated%3A2024-04-27..2024-06-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.25.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-judge",
-    "version": "1.26.1-rc0",
+    "version": "1.26.1-rc1",
     "description": "A simple online judge for Jupyter Lab.",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-judge",
-    "version": "1.26.0",
+    "version": "1.26.1-rc0",
     "description": "A simple online judge for Jupyter Lab.",
     "keywords": [
         "jupyter",

--- a/src/components/SubmissionControl.tsx
+++ b/src/components/SubmissionControl.tsx
@@ -1,17 +1,24 @@
 import styled from '@emotion/styled';
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, ReactNode } from 'react';
 import {
   JudgeError,
   JudgeKernelNotConnectedError,
   JudgePanel
 } from '../widgets/JudgePanel';
-import { transContext } from '../widgets/JudgeSubmissionArea';
+import { factoryContext, transContext } from '../widgets/JudgeSubmissionArea';
+
+export interface IControlButtonProps {
+  onClick: () => Promise<void>;
+  disabled?: boolean;
+  children: ReactNode;
+}
 
 export function SubmissionControl(props: {
   className?: string;
   panel: JudgePanel;
 }): JSX.Element {
   const trans = useContext(transContext);
+  const { controlButtonFactory: ControlButton } = useContext(factoryContext);
   const [inProgress, setInProgress] = useState(false);
 
   return (
@@ -53,7 +60,7 @@ const ControlContainer = styled.div`
   background: var(--jp-layout-color2);
 `;
 
-const ControlButton = styled.button`
+export const ControlButtonImpl = styled.button`
   display: block;
   margin-top: 12px;
   margin-left: 20px;

--- a/src/components/SubmissionControl.tsx
+++ b/src/components/SubmissionControl.tsx
@@ -7,12 +7,6 @@ import {
 } from '../widgets/JudgePanel';
 import { factoryContext, transContext } from '../widgets/JudgeSubmissionArea';
 
-export interface IControlButtonProps {
-  onClick: () => Promise<void>;
-  disabled?: boolean;
-  children: ReactNode;
-}
-
 export function SubmissionControl(props: {
   className?: string;
   panel: JudgePanel;
@@ -60,7 +54,22 @@ const ControlContainer = styled.div`
   background: var(--jp-layout-color2);
 `;
 
-export const ControlButtonImpl = styled.button`
+export interface IControlButtonProps {
+  onClick: () => Promise<void>;
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+export function ControlButtonImpl(props: IControlButtonProps): JSX.Element {
+  const { children, onClick, disabled } = props;
+  return (
+    <ControlButton onClick={onClick} disabled={disabled}>
+      {children}
+    </ControlButton>
+  );
+}
+
+const ControlButton = styled.button`
   display: block;
   margin-top: 12px;
   margin-left: 20px;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { JSONObject } from '@lumino/coreutils';
 import { JudgeModel } from './model';
 import {
+  IControlButtonFactory,
   IJudgePanelFactory,
   IJudgeSignal,
   IJudgeSubmissionAreaFactory,
@@ -38,6 +39,7 @@ import { Signal } from '@lumino/signaling';
 import { JudgeSubmissionArea } from './widgets/JudgeSubmissionArea';
 import { JudgeTerminal } from './widgets/JudgeTerminal';
 import { SubmissionListImpl } from './components/SubmissionList';
+import { ControlButtonImpl } from './components';
 
 /**
  * A signal that emits whenever a submission is submitted.
@@ -85,6 +87,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     IJudgeSubmissionAreaFactory,
     IJudgeTerminalFactory,
     ISubmissionListFactory,
+    IControlButtonFactory,
     IProblemProvider,
     ISettingRegistry,
     ILayoutRestorer
@@ -102,6 +105,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     judgeSubmissionAreaFactory: IJudgeSubmissionAreaFactory | null,
     judgeTerminalFactory: IJudgeTerminalFactory | null,
     submissionListFactory: ISubmissionListFactory | null,
+    controlButtonFactory: IControlButtonFactory | null,
     problemProvider: IProblemProvider | null,
     settingRegistry: ISettingRegistry | null,
     restorer: ILayoutRestorer | null
@@ -143,6 +147,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         judgeTerminalFactory ??
         ((options: JudgeTerminal.IOptions) => new JudgeTerminal(options)),
       submissionListFactory: submissionListFactory ?? SubmissionListImpl,
+      controlButtonFactory: controlButtonFactory ?? ControlButtonImpl,
       submitted,
       executed,
       factoryOptions: {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -8,6 +8,8 @@ import { JudgePanel } from './widgets/JudgePanel';
 import { JudgeSubmissionArea } from './widgets/JudgeSubmissionArea';
 import { JudgeTerminal } from './widgets/JudgeTerminal';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+import { IControlButtonProps } from './components';
+import { ReactNode } from 'react';
 
 /**
  * The Problem Provider token.
@@ -60,6 +62,12 @@ export const ISubmissionListFactory = new Token<ISubmissionListFactory>(
 export type ISubmissionListFactory = (
   options: SubmissionList.IOptions
 ) => JSX.Element;
+
+export const IControlButtonFactory = new Token<ISubmissionListFactory | null>(
+  `${PLUGIN_ID}:IControlButtonFactory`
+);
+
+export type IControlButtonFactory = (props: IControlButtonProps) => ReactNode;
 
 export const IJudgeSignal = new Token<IJudgeSignal>(
   `${PLUGIN_ID}:IJudgeSignal`

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -62,11 +62,13 @@ export type ISubmissionListFactory = (
   options: SubmissionList.IOptions
 ) => JSX.Element;
 
-export const IControlButtonFactory = new Token<ISubmissionListFactory | null>(
+export const IControlButtonFactory = new Token<IControlButtonFactory>(
   `${PLUGIN_ID}:IControlButtonFactory`
 );
 
-export type IControlButtonFactory = (props: IControlButtonProps) => JSX.Element;
+export type IControlButtonFactory =
+  | ((props: IControlButtonProps) => JSX.Element)
+  | null;
 
 export const IJudgeSignal = new Token<IJudgeSignal>(
   `${PLUGIN_ID}:IJudgeSignal`

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -9,7 +9,6 @@ import { JudgeSubmissionArea } from './widgets/JudgeSubmissionArea';
 import { JudgeTerminal } from './widgets/JudgeTerminal';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IControlButtonProps } from './components';
-import { ReactNode } from 'react';
 
 /**
  * The Problem Provider token.
@@ -67,7 +66,7 @@ export const IControlButtonFactory = new Token<ISubmissionListFactory | null>(
   `${PLUGIN_ID}:IControlButtonFactory`
 );
 
-export type IControlButtonFactory = (props: IControlButtonProps) => ReactNode;
+export type IControlButtonFactory = (props: IControlButtonProps) => JSX.Element;
 
 export const IJudgeSignal = new Token<IJudgeSignal>(
   `${PLUGIN_ID}:IJudgeSignal`

--- a/src/widgets/JudgePanel.ts
+++ b/src/widgets/JudgePanel.ts
@@ -41,7 +41,6 @@ import { JudgeSignal } from '../tokens';
 import { customJudgeColorSvg } from '@team-monolith/cds';
 import { IJudgeProblemPanel, JudgeProblemPanel } from './JudgeProblemPanel';
 import { IControlButtonProps } from '../components';
-import { ReactNode } from 'react';
 
 function bytesToBase64(bytes: Uint8Array) {
   const binString = Array.from(bytes, byte => String.fromCodePoint(byte)).join(
@@ -127,7 +126,7 @@ export namespace JudgePanel {
       options: JudgeTerminal.IOptions
     ) => JudgeTerminal.IJudgeTerminal;
     submissionListFactory: (options: SubmissionList.IOptions) => JSX.Element;
-    controlButtonFactory: (props: IControlButtonProps) => ReactNode;
+    controlButtonFactory: (props: IControlButtonProps) => JSX.Element;
   }
 }
 
@@ -785,7 +784,7 @@ export class JudgeDocumentFactory extends ABCWidgetFactory<
   private _submissionListFactory: (
     options: SubmissionList.IOptions
   ) => JSX.Element;
-  private _controlButtonFactory: (props: IControlButtonProps) => ReactNode;
+  private _controlButtonFactory: (props: IControlButtonProps) => JSX.Element;
   private _submitted: Signal<any, JudgeSignal.ISubmissionArgs>;
   private _executed: Signal<any, JudgeSignal.IExecutionArgs>;
 }
@@ -818,7 +817,7 @@ export namespace JudgeDocumentFactory {
       options: JudgeTerminal.IOptions
     ) => JudgeTerminal.IJudgeTerminal;
     submissionListFactory: (options: SubmissionList.IOptions) => JSX.Element;
-    controlButtonFactory: (props: IControlButtonProps) => ReactNode;
+    controlButtonFactory: (props: IControlButtonProps) => JSX.Element;
     submitted: Signal<any, JudgeSignal.ISubmissionArgs>;
     executed: Signal<any, JudgeSignal.IExecutionArgs>;
   }

--- a/src/widgets/JudgePanel.ts
+++ b/src/widgets/JudgePanel.ts
@@ -40,6 +40,8 @@ import { IKernelConnection } from '@jupyterlab/services/lib/kernel/kernel';
 import { JudgeSignal } from '../tokens';
 import { customJudgeColorSvg } from '@team-monolith/cds';
 import { IJudgeProblemPanel, JudgeProblemPanel } from './JudgeProblemPanel';
+import { IControlButtonProps } from '../components';
+import { ReactNode } from 'react';
 
 function bytesToBase64(bytes: Uint8Array) {
   const binString = Array.from(bytes, byte => String.fromCodePoint(byte)).join(
@@ -125,6 +127,7 @@ export namespace JudgePanel {
       options: JudgeTerminal.IOptions
     ) => JudgeTerminal.IJudgeTerminal;
     submissionListFactory: (options: SubmissionList.IOptions) => JSX.Element;
+    controlButtonFactory: (props: IControlButtonProps) => ReactNode;
   }
 }
 
@@ -177,7 +180,8 @@ export class JudgePanel extends BoxPanel {
       panel: this,
       model: this.model,
       translator: this._translator,
-      submissionListFactory: options.submissionListFactory
+      submissionListFactory: options.submissionListFactory,
+      controlButtonFactory: options.controlButtonFactory
     });
     submissionPanel.addClass('jp-JudgePanel-submissionPanel');
 
@@ -730,6 +734,7 @@ export class JudgeDocumentFactory extends ABCWidgetFactory<
     this._judgeSubmissionAreaFactory = options.judgeSubmissionAreaFactory;
     this._judgeTerminalFactory = options.judgeTerminalFactory;
     this._submissionListFactory = options.submissionListFactory;
+    this._controlButtonFactory = options.controlButtonFactory;
     this._submitted = options.submitted;
     this._executed = options.executed;
   }
@@ -751,7 +756,8 @@ export class JudgeDocumentFactory extends ABCWidgetFactory<
       executed: this._executed,
       judgeSubmissionAreaFactory: this._judgeSubmissionAreaFactory,
       judgeTerminalFactory: this._judgeTerminalFactory,
-      submissionListFactory: this._submissionListFactory
+      submissionListFactory: this._submissionListFactory,
+      controlButtonFactory: this._controlButtonFactory
     });
 
     judgePanel.title.icon = JudgeColorLabIcon;
@@ -779,6 +785,7 @@ export class JudgeDocumentFactory extends ABCWidgetFactory<
   private _submissionListFactory: (
     options: SubmissionList.IOptions
   ) => JSX.Element;
+  private _controlButtonFactory: (props: IControlButtonProps) => ReactNode;
   private _submitted: Signal<any, JudgeSignal.ISubmissionArgs>;
   private _executed: Signal<any, JudgeSignal.IExecutionArgs>;
 }
@@ -811,6 +818,7 @@ export namespace JudgeDocumentFactory {
       options: JudgeTerminal.IOptions
     ) => JudgeTerminal.IJudgeTerminal;
     submissionListFactory: (options: SubmissionList.IOptions) => JSX.Element;
+    controlButtonFactory: (props: IControlButtonProps) => ReactNode;
     submitted: Signal<any, JudgeSignal.ISubmissionArgs>;
     executed: Signal<any, JudgeSignal.IExecutionArgs>;
   }

--- a/src/widgets/JudgeSubmissionArea.tsx
+++ b/src/widgets/JudgeSubmissionArea.tsx
@@ -4,7 +4,7 @@ import {
   nullTranslator,
   TranslationBundle
 } from '@jupyterlab/translation';
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { SubmissionArea } from '../components/SubmissionArea';
 import {
@@ -22,7 +22,7 @@ export const transContext = React.createContext<TranslationBundle>(
 
 export const factoryContext = React.createContext<{
   submissionListFactory: (props: SubmissionList.IOptions) => JSX.Element;
-  controlButtonFactory: (props: IControlButtonProps) => ReactNode;
+  controlButtonFactory: (props: IControlButtonProps) => JSX.Element;
 }>({
   submissionListFactory: SubmissionListImpl,
   controlButtonFactory: ControlButtonImpl
@@ -34,7 +34,7 @@ export namespace JudgeSubmissionArea {
     model: JudgeModel;
     translator: ITranslator;
     submissionListFactory: (props: SubmissionList.IOptions) => JSX.Element;
-    controlButtonFactory: (props: IControlButtonProps) => ReactNode;
+    controlButtonFactory: (props: IControlButtonProps) => JSX.Element;
   }
 }
 
@@ -47,7 +47,7 @@ export class JudgeSubmissionArea extends ReactWidget {
   private _submissionListFactory: (
     props: SubmissionList.IOptions
   ) => JSX.Element;
-  private _controlButtonFactory: (props: IControlButtonProps) => ReactNode;
+  private _controlButtonFactory: (props: IControlButtonProps) => JSX.Element;
 
   constructor(options: JudgeSubmissionArea.IOptions) {
     super();

--- a/src/widgets/JudgeSubmissionArea.tsx
+++ b/src/widgets/JudgeSubmissionArea.tsx
@@ -4,7 +4,7 @@ import {
   nullTranslator,
   TranslationBundle
 } from '@jupyterlab/translation';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { SubmissionArea } from '../components/SubmissionArea';
 import {
@@ -14,6 +14,7 @@ import {
 import { TRANSLATOR_DOMAIN } from '../constants';
 import { JudgeModel } from '../model';
 import { JudgePanel } from './JudgePanel';
+import { ControlButtonImpl, IControlButtonProps } from '../components';
 
 export const transContext = React.createContext<TranslationBundle>(
   nullTranslator.load(TRANSLATOR_DOMAIN)
@@ -21,8 +22,10 @@ export const transContext = React.createContext<TranslationBundle>(
 
 export const factoryContext = React.createContext<{
   submissionListFactory: (props: SubmissionList.IOptions) => JSX.Element;
+  controlButtonFactory: (props: IControlButtonProps) => ReactNode;
 }>({
-  submissionListFactory: SubmissionListImpl
+  submissionListFactory: SubmissionListImpl,
+  controlButtonFactory: ControlButtonImpl
 });
 
 export namespace JudgeSubmissionArea {
@@ -31,6 +34,7 @@ export namespace JudgeSubmissionArea {
     model: JudgeModel;
     translator: ITranslator;
     submissionListFactory: (props: SubmissionList.IOptions) => JSX.Element;
+    controlButtonFactory: (props: IControlButtonProps) => ReactNode;
   }
 }
 
@@ -43,6 +47,7 @@ export class JudgeSubmissionArea extends ReactWidget {
   private _submissionListFactory: (
     props: SubmissionList.IOptions
   ) => JSX.Element;
+  private _controlButtonFactory: (props: IControlButtonProps) => ReactNode;
 
   constructor(options: JudgeSubmissionArea.IOptions) {
     super();
@@ -51,12 +56,16 @@ export class JudgeSubmissionArea extends ReactWidget {
     this._model = options.model;
     this._trans = options.translator.load(TRANSLATOR_DOMAIN);
     this._submissionListFactory = options.submissionListFactory;
+    this._controlButtonFactory = options.controlButtonFactory;
   }
 
   render(): JSX.Element {
     return (
       <factoryContext.Provider
-        value={{ submissionListFactory: this._submissionListFactory }}
+        value={{
+          submissionListFactory: this._submissionListFactory,
+          controlButtonFactory: this._controlButtonFactory
+        }}
       >
         <transContext.Provider value={this._trans}>
           <QueryClientProvider client={this.queryClient}>


### PR DESCRIPTION
### Added `controlButtonFactory` token
This token allows users to replace the default 'Submit' button with a custom component that includes their own design and logic.