### PR TITLE
Handle future dates correctly in createdAtText formatting

### DIFF
--- a/src/components/SubmissionItem.tsx
+++ b/src/components/SubmissionItem.tsx
@@ -12,7 +12,14 @@ export function SubmissionItem(props: {
 }): JSX.Element {
   const trans = useContext(transContext);
 
-  const createdAtText = Time.formatHuman(new Date(props.submission.createdAt));
+  // "formatHuman" has a bug that it does not handle future dates correctly.
+  // https://github.com/jupyterlab/jupyterlab/issues/16254
+  const createdDate = new Date(props.submission.createdAt);
+  const now = new Date();
+  const createdAtText =
+    createdDate.getTime() > now.getTime()
+      ? Time.formatHuman(now) // If the date is in the future, use current time
+      : Time.formatHuman(createdDate);
   const createdAtTitle = Time.format(new Date(props.submission.createdAt));
 
   return (


### PR DESCRIPTION
# Issue
- The `Time.formatHuman` helper from JupyterLab mishandles future `Date` objects, producing incorrect strings (e.g. “next year”).  
- See upstream report: https://github.com/jupyterlab/jupyterlab/issues/16254.  
- This manifests when a submission’s `createdAt` value is ahead of the current clock—​for example after clock-skewed data imports or during tests that stub the system time.

# Code changes
- Parse `props.submission.createdAt` once as `createdDate` and capture `now`.  
- If `createdDate` is **in the future** (`createdDate.getTime() > now.getTime()`), call `Time.formatHuman(now)` instead of passing the future date.  
- Otherwise, fall back to the original behaviour (`Time.formatHuman(createdDate)`).  
- Added explanatory comments in-line, including the upstream issue URL, so the workaround can be removed once the library bug is fixed.
