### PR TITLE
Update Korean error message

### DIFF
--- a/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.json
+++ b/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.json
@@ -27,7 +27,7 @@
         "\uc77d\uae30 \uc804\uc6a9 \ubb38\uc11c\uc785\ub2c8\ub2e4"
     ],
     "Error": [
-        "\uc624\ub958 \ubc1c\uc0dd"
+        "\ub0b4 \ucf54\ub4dc \uc624\ub958"
     ],
     "Execute": [
         "\uc2e4\ud589"

--- a/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.json
+++ b/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.json
@@ -26,8 +26,8 @@
     "Document is read-only": [
         "\uc77d\uae30 \uc804\uc6a9 \ubb38\uc11c\uc785\ub2c8\ub2e4"
     ],
-    "Error": [
-        "\ub0b4 \ucf54\ub4dc \uc624\ub958"
+    "Coding Error": [
+        "\ucf54\ub529 \uc624\ub958"
     ],
     "Execute": [
         "\uc2e4\ud589"

--- a/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.po
+++ b/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.po
@@ -85,7 +85,7 @@ msgstr "틀렸습니다."
 
 #: src/components/SubmissionItemStatus.tsx:26
 msgid "Error"
-msgstr "오류 발생"
+msgstr "내 코드 오류"
 
 #: src/components/SubmissionItemStatus.tsx:29
 msgid "Time Limit"

--- a/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.po
+++ b/jupyterlab_judge/locale/ko_KR/LC_MESSAGES/jupyterlab_judge.po
@@ -84,8 +84,8 @@ msgid "Wrong"
 msgstr "틀렸습니다."
 
 #: src/components/SubmissionItemStatus.tsx:26
-msgid "Error"
-msgstr "내 코드 오류"
+msgid "Coding Error"
+msgstr "코딩 오류"
 
 #: src/components/SubmissionItemStatus.tsx:29
 msgid "Time Limit"

--- a/src/components/SubmissionItemStatus.tsx
+++ b/src/components/SubmissionItemStatus.tsx
@@ -23,7 +23,7 @@ export function SubmissionItemStatus(props: {
       title = `(${props.acceptedCount}/${props.totalCount})`;
       break;
     case 'RE':
-      content = `🚫 ${trans.__('Error')}`;
+      content = `🚫 ${trans.__('Coding Error')}`;
       break;
     case 'TLE':
       content = `🕓 ${trans.__('Time Limit')}`;


### PR DESCRIPTION
## Background
- Users are confused with errored submissions. They think "Error" means "Service Error" not "Implementation Error"

## Summary
- Change display text for errored submission from "Error" to "Coding Error"
  - For Korean, "오류 발생" to "코딩 오류"
