### PR TITLE
chore: merge release/1.30.0rc1 back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.30.0rc1
+
+([Full Changelog](https://github.com/team-monolith-product/jupyterlab-judge/compare/v1.29.1...d3ddbd05d3d27a2f6ef0414ba371706856c43476))
+
+### Merged PRs
+
+- TASK-5508 저지문제 열기시 signal [#72](https://github.com/team-monolith-product/jupyterlab-judge/pull/72) ([@shcshcshc](https://github.com/shcshcshc))
+
+### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/use/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-judge/graphs/contributors?from=2026-01-18&to=2026-04-30&type=c))
+
+@shcshcshc ([activity](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-judge+involves%3Ashcshcshc+updated%3A2026-01-18..2026-04-30&type=Issues))
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.29.1
 
 ([Full Changelog](https://github.com/team-monolith-product/jupyterlab-judge/compare/v1.29.0...72d11ed74ec4f5448ad857edc14a9fe22193e4a1))
@@ -18,8 +37,6 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 ([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-judge/graphs/contributors?from=2026-01-17&to=2026-01-18&type=c))
 
 @a3626a ([activity](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-judge+involves%3Aa3626a+updated%3A2026-01-17..2026-01-18&type=Issues)) | @claude ([activity](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-judge+involves%3Aclaude+updated%3A2026-01-17..2026-01-18&type=Issues))
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.29.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-judge",
-    "version": "1.29.1",
+    "version": "1.30.0-rc1",
     "description": "A simple online judge for Jupyter Lab.",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-judge",
-    "version": "1.29.1",
+    "version": "1.30.0",
     "description": "A simple online judge for Jupyter Lab.",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-judge",
-    "version": "1.30.0",
+    "version": "1.29.1",
     "description": "A simple online judge for Jupyter Lab.",
     "keywords": [
         "jupyter",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,8 +8,9 @@ import { ServerConnection } from '@jupyterlab/services';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { JudgeModel } from './model';
 import { JUDGE_HIDDEN_FOLDER_NAME, PLUGIN_ID } from './constants';
-import { IProblemProvider } from './tokens';
+import { IProblemProvider, JudgeSignal } from './tokens';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { Signal } from '@lumino/signaling';
 
 /**
  * The command IDs used by the fileeditor plugin.
@@ -34,7 +35,8 @@ export function addCommands(
   trans: TranslationBundle,
   docManager: IDocumentManager,
   tracker: WidgetTracker<JudgeDocument>,
-  problemProvider: IProblemProvider
+  problemProvider: IProblemProvider,
+  opened: Signal<any, JudgeSignal.IOpenedArgs>
 ): void {
   commands.addCommand(CommandIDs.open, {
     execute: async (args: any) => {
@@ -49,7 +51,8 @@ export function addCommands(
         await openOrCreateFromId(
           problemProvider,
           docManager,
-          args.problemId as string
+          args.problemId as string,
+          opened
         );
       }
     },
@@ -104,7 +107,8 @@ export function addCommands(
 export async function openOrCreateFromId(
   problemProvider: IProblemProvider,
   docManager: IDocumentManager,
-  problemId: string
+  problemId: string,
+  opened: Signal<any, JudgeSignal.IOpenedArgs>
 ): Promise<IDocumentWidget | undefined> {
   const problem = await problemProvider.getProblem(problemId);
   if (problem) {
@@ -121,7 +125,14 @@ export async function openOrCreateFromId(
       name: directoryId,
       type: 'directory'
     });
-    return await openOrCreate(problemProvider, docManager, path, problemId);
+    const widget = await openOrCreate(
+      problemProvider,
+      docManager,
+      path,
+      problemId
+    );
+    opened.emit({ problemId });
+    return widget;
   }
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,6 +28,11 @@ export namespace CommandIDs {
 }
 
 /**
+ * A signal that emits whenever a problem is opened via openOrCreateFromId.
+ */
+export const opened = new Signal<any, JudgeSignal.IOpenedArgs>({});
+
+/**
  * Wrapper function for adding the default File Editor commands
  */
 export function addCommands(
@@ -35,8 +40,7 @@ export function addCommands(
   trans: TranslationBundle,
   docManager: IDocumentManager,
   tracker: WidgetTracker<JudgeDocument>,
-  problemProvider: IProblemProvider,
-  opened: Signal<any, JudgeSignal.IOpenedArgs>
+  problemProvider: IProblemProvider
 ): void {
   commands.addCommand(CommandIDs.open, {
     execute: async (args: any) => {
@@ -51,8 +55,7 @@ export function addCommands(
         await openOrCreateFromId(
           problemProvider,
           docManager,
-          args.problemId as string,
-          opened
+          args.problemId as string
         );
       }
     },
@@ -107,8 +110,7 @@ export function addCommands(
 export async function openOrCreateFromId(
   problemProvider: IProblemProvider,
   docManager: IDocumentManager,
-  problemId: string,
-  opened: Signal<any, JudgeSignal.IOpenedArgs>
+  problemId: string
 ): Promise<IDocumentWidget | undefined> {
   const problem = await problemProvider.getProblem(problemId);
   if (problem) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,9 +8,9 @@ import { ServerConnection } from '@jupyterlab/services';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { JudgeModel } from './model';
 import { JUDGE_HIDDEN_FOLDER_NAME, PLUGIN_ID } from './constants';
-import { IProblemProvider, JudgeSignal } from './tokens';
+import { IProblemProvider } from './tokens';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { Signal } from '@lumino/signaling';
+import { opened } from './judgeSignal';
 
 /**
  * The command IDs used by the fileeditor plugin.
@@ -26,11 +26,6 @@ export namespace CommandIDs {
   export const run = `${PLUGIN_ID}:plugin:run`;
   export const runAll = `${PLUGIN_ID}:plugin:run-all`;
 }
-
-/**
- * A signal that emits whenever a problem is opened via openOrCreateFromId.
- */
-export const opened = new Signal<any, JudgeSignal.IOpenedArgs>({});
 
 /**
  * Wrapper function for adding the default File Editor commands

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -122,14 +122,7 @@ export async function openOrCreateFromId(
       name: directoryId,
       type: 'directory'
     });
-    const widget = await openOrCreate(
-      problemProvider,
-      docManager,
-      path,
-      problemId
-    );
-    opened.emit({ problemId });
-    return widget;
+    return openOrCreate(problemProvider, docManager, path, problemId);
   }
 }
 
@@ -155,6 +148,7 @@ async function openOrCreate(
     }
     throw e;
   } finally {
+    opened.emit({ problemId });
     // eslint-disable-next-line no-unsafe-finally
     return docManager.openOrReveal(path);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ const submitted = new Signal<any, JudgeSignal.ISubmissionArgs>({});
  */
 const executed = new Signal<any, JudgeSignal.IExecutionArgs>({});
 
+/**
+ * A signal that emits whenever a problem is opened via openOrCreateFromId.
+ */
+const opened = new Signal<any, JudgeSignal.IOpenedArgs>({});
+
 const signal: JupyterFrontEndPlugin<IJudgeSignal> = {
   id: `${PLUGIN_ID}:IJudgeSignal`,
   provides: IJudgeSignal,
@@ -61,6 +66,9 @@ const signal: JupyterFrontEndPlugin<IJudgeSignal> = {
       },
       get executed() {
         return executed;
+      },
+      get opened() {
+        return opened;
       }
     };
   },
@@ -192,7 +200,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
       trans,
       docManager,
       tracker,
-      problemProviderWithDefault
+      problemProviderWithDefault,
+      opened
     );
     addMenuItems(menu, tracker, trans);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   JudgePanel
 } from './widgets/JudgePanel';
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
-import { addCommands, addMenuItems, CommandIDs } from './commands';
+import { addCommands, addMenuItems, CommandIDs, opened } from './commands';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IMainMenu } from '@jupyterlab/mainmenu';
@@ -50,11 +50,6 @@ const submitted = new Signal<any, JudgeSignal.ISubmissionArgs>({});
  * A signal that emits when code is executed.
  */
 const executed = new Signal<any, JudgeSignal.IExecutionArgs>({});
-
-/**
- * A signal that emits whenever a problem is opened via openOrCreateFromId.
- */
-const opened = new Signal<any, JudgeSignal.IOpenedArgs>({});
 
 const signal: JupyterFrontEndPlugin<IJudgeSignal> = {
   id: `${PLUGIN_ID}:IJudgeSignal`,
@@ -200,8 +195,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       trans,
       docManager,
       tracker,
-      problemProviderWithDefault,
-      opened
+      problemProviderWithDefault
     );
     addMenuItems(menu, tracker, trans);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   JudgePanel
 } from './widgets/JudgePanel';
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
-import { addCommands, addMenuItems, CommandIDs, opened } from './commands';
+import { addCommands, addMenuItems, CommandIDs } from './commands';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IMainMenu } from '@jupyterlab/mainmenu';
@@ -31,25 +31,14 @@ import {
   IJudgeSubmissionAreaFactory,
   IJudgeTerminalFactory,
   IProblemProvider,
-  ISubmissionListFactory,
-  JudgeSignal
+  ISubmissionListFactory
 } from './tokens';
 import { HardCodedProblemProvider } from './problemProvider/HardCodedProblemProvider';
-import { Signal } from '@lumino/signaling';
 import { JudgeSubmissionArea } from './widgets/JudgeSubmissionArea';
 import { JudgeTerminal } from './widgets/JudgeTerminal';
 import { SubmissionListImpl } from './components/SubmissionList';
 import { ControlButtonImpl } from './components';
-
-/**
- * A signal that emits whenever a submission is submitted.
- */
-const submitted = new Signal<any, JudgeSignal.ISubmissionArgs>({});
-
-/**
- * A signal that emits when code is executed.
- */
-const executed = new Signal<any, JudgeSignal.IExecutionArgs>({});
+import { submitted, executed, opened } from './judgeSignal';
 
 const signal: JupyterFrontEndPlugin<IJudgeSignal> = {
   id: `${PLUGIN_ID}:IJudgeSignal`,

--- a/src/judgeSignal.ts
+++ b/src/judgeSignal.ts
@@ -1,0 +1,17 @@
+import { Signal } from '@lumino/signaling';
+import { JudgeSignal } from './tokens';
+
+/**
+ * A signal that emits whenever a submission is submitted.
+ */
+export const submitted = new Signal<any, JudgeSignal.ISubmissionArgs>({});
+
+/**
+ * A signal that emits when code is executed.
+ */
+export const executed = new Signal<any, JudgeSignal.IExecutionArgs>({});
+
+/**
+ * A signal that emits whenever a problem is opened via openOrCreateFromId.
+ */
+export const opened = new Signal<any, JudgeSignal.IOpenedArgs>({});

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -77,6 +77,7 @@ export const IJudgeSignal = new Token<IJudgeSignal>(
 export interface IJudgeSignal {
   readonly submitted: ISignal<any, JudgeSignal.ISubmissionArgs>;
   readonly executed: ISignal<any, JudgeSignal.IExecutionArgs>;
+  readonly opened: ISignal<any, JudgeSignal.IOpenedArgs>;
 }
 
 export namespace JudgeSignal {
@@ -90,5 +91,9 @@ export namespace JudgeSignal {
     widget: JudgePanel;
     cell: CodeEditor.IModel;
     success: boolean;
+  }
+
+  export interface IOpenedArgs {
+    problemId: string;
   }
 }


### PR DESCRIPTION
# Summary

Merge `release/1.30.0rc1` back into `main`. Brings the changes from PR #72 — which was first merged into a temporary release branch for RC validation — into `main`.

# Included Changes

The `IJudgeSignal.opened` signal introduced in PR #72 (see #72), plus a follow-up refactor from review feedback on this PR.

| File | Change |
|---|---|
| `src/tokens.ts` | Add `IJudgeSignal.opened`, `JudgeSignal.IOpenedArgs` |
| `src/commands.ts` | Emit `opened.emit({ problemId })` inside `openOrCreate` (the function that actually opens the widget) |
| `src/judgeSignal.ts` (new) | Aggregate `submitted` / `executed` / `opened` Signal instances |
| `src/index.ts` | Update Signal instance import source; expose `opened` provider |

# Background

`jupyter-releaser`'s prep-release expects PRs to already be merged into the base branch before generating the changelog. To publish 1.30.0rc1 to npm under the `next` tag for downstream validation prior to merging into `main`, a temporary `release/1.30.0rc1` branch was created and PR #72 was merged there. Now that RC validation is complete, the same changes are being applied to `main`.

# Backwards Compatibility

Same as PR #72. Compatible with existing `IJudgeSignal` consumers.

# Follow-ups

- After this PR is merged, run the formal 1.30.0 release procedure (prep-release → publish-release) on `main`.
- Clean up the temporary `release/1.30.0rc1` branch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)